### PR TITLE
Show RAM usage (max rss) in UI for Linux systems

### DIFF
--- a/MP-APS/Core/GUISystem.cpp
+++ b/MP-APS/Core/GUISystem.cpp
@@ -49,16 +49,17 @@ void GUISystem::Render(const int framebufferWidth,
 	nk_glfw3_new_frame();
 
 	const auto frameStatFlags = NK_WINDOW_BORDER | NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_NO_INPUT;
-	if (nk_begin(m_nuklearContext, "Frame Stats", nk_rect(0, framebufferHeight - 40, 500, 40), frameStatFlags)) {
+	if (nk_begin(m_nuklearContext, "Frame Stats", nk_rect(0, framebufferHeight - 40, 720, 40), frameStatFlags)) {
 		nk_layout_row_begin(m_nuklearContext, NK_STATIC, 0, 1);
 		{
-			nk_layout_row_push(m_nuklearContext, 500);
+			nk_layout_row_push(m_nuklearContext, 720);
             nk_label(
 				m_nuklearContext,
-				fmt::format("Frame Time: {:.2f} ms ({:.0f} fps) | GPU VRAM Usage: {} MB",
+				fmt::format("Frame Time: {:.2f} ms ({:.0f} fps) | GPU VRAM Usage: {} MB | RAM Usage: {} MB",
 						frameStats.frameTimeMilliseconds,
 						1.0 / (frameStats.frameTimeMilliseconds / 1000.0),
-						frameStats.videoMemoryUsageKB / 1000
+						frameStats.videoMemoryUsageKB / 1000,
+						frameStats.ramUsageKB / 1000
 					).c_str(),
 				NK_TEXT_LEFT
 			);

--- a/MP-APS/Engine.cpp
+++ b/MP-APS/Engine.cpp
@@ -6,6 +6,7 @@
 #include "ResourceManager.h"
 #include "SceneBase.h"
 #include "FrameStats.h"
+#include "Platform/Platform.h"
 
 #include <GLFW/glfw3.h>
 #include <pugixml.hpp>
@@ -120,6 +121,7 @@ void Engine::Execute() {
 			const auto frameTime{ frameTimeMilliseconds(numFramesRendered) };		
 			frameStats.frameTimeMilliseconds = frameTime;
 			frameStats.videoMemoryUsageKB = m_renderer.GetVideoMemUsageKB();
+			frameStats.ramUsageKB = Platform::maxRSSKb();
 
 			numFramesRendered = 0;
 			hasOneSecondPassed = false;

--- a/MP-APS/FrameStats.h
+++ b/MP-APS/FrameStats.h
@@ -3,4 +3,5 @@
 struct FrameStats {
     double frameTimeMilliseconds{ 0.0 };
     int videoMemoryUsageKB{ 0 };
+    long ramUsageKB{ 0 };
 };

--- a/MP-APS/Platform/Platform.h
+++ b/MP-APS/Platform/Platform.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#ifdef __linux__
+    #include <sys/resource.h>
+#endif
+
+namespace Platform {
+    long maxRSSKb() noexcept {
+#ifdef __linux__
+        // https://man7.org/linux/man-pages/man2/getrusage.2.html
+        rusage ru;
+        const auto result{ getrusage(RUSAGE_SELF, &ru) };
+
+        if (result == -1) {
+            return 0;
+        }
+
+        return ru.ru_maxrss;
+#else
+        #warning "Platform::maxRSSKb not implemented for this platform."
+        return 0;
+#endif
+    }
+};


### PR DESCRIPTION
Compiler warning will display for other platforms and default to showing 0.

See bottom left corner:
![image](https://user-images.githubusercontent.com/5572045/142343301-be862800-a619-4e46-ad08-cbccf49d557a.png)
