### PR TITLE
Use texture compression in `ResourceManager::LoadTexture`

### DIFF
--- a/MP-APS/ResourceManager.cpp
+++ b/MP-APS/ResourceManager.cpp
@@ -99,20 +99,24 @@ unsigned int ResourceManager::LoadTexture(const std::string_view path, const boo
 	}
 
 	GLenum format = 0;
+	GLenum internalFormat = 0;
 	switch (nrComponents) {
 	case 1:
 		format = GL_RED;
+		internalFormat = GL_COMPRESSED_RED;
 		break;
 	case 3:
 		format = GL_RGB;
+		internalFormat = GL_COMPRESSED_RGB;
 		break;
 	case 4:
 		format = GL_RGBA;
+		internalFormat = GL_COMPRESSED_RGBA;
 		break;
 	}
 
 	glBindTexture(GL_TEXTURE_2D, textureID);
-	glTexImage2D(GL_TEXTURE_2D, 0, format, width, height, 0, format, GL_UNSIGNED_BYTE, data);
+	glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, width, height, 0, format, GL_UNSIGNED_BYTE, data);
 	if (useMipMaps) {
 		glGenerateMipmap(GL_TEXTURE_2D);
 	}

--- a/MP-APS/ResourceManager.cpp
+++ b/MP-APS/ResourceManager.cpp
@@ -10,6 +10,16 @@
 #define STBI_FAILURE_USERMSG
 #include <stb_image.h>
 
+const static std::filesystem::path COMPRESSED_TEX_DIR{ std::filesystem::current_path() / "Data/cache/textures" };
+
+struct CompressedImageDesc {
+	GLint width{ -1 };
+	GLint height{ -1 };
+	GLint size{ -1 };
+	GLint format{ -1 };
+	unsigned char* data{ nullptr };
+};
+
 /***********************************************************************************/
 void ResourceManager::ReleaseAllResources() {
 	// Delete cached meshes
@@ -72,66 +82,149 @@ unsigned int ResourceManager::LoadHDRI(const std::string_view path) const {
 }
 
 /***********************************************************************************/
-unsigned int ResourceManager::LoadTexture(const std::string_view path, const bool useMipMaps, const bool useUnalignedUnpack) {
+auto buildTextureCachePath(const std::filesystem::path& filenameNoExt) {
+	const std::filesystem::path filename{ filenameNoExt.string() + ".bin" };
+	return std::filesystem::path( COMPRESSED_TEX_DIR / filename);
+}
 
-	// Check if texture is already loaded somewhere
-	const auto val = m_textureCache.find(path.data());
+/***********************************************************************************/
+void saveCompressedImageToDisk(const std::filesystem::path& target, const CompressedImageDesc& desc) {
+	if (!std::filesystem::exists(COMPRESSED_TEX_DIR)) {
+		if (!std::filesystem::create_directories(COMPRESSED_TEX_DIR)) {
+			std::cerr << "Failed to create texture cache directory: " << COMPRESSED_TEX_DIR << '\n';
+			return;
+		}
+	}
+
+	std::ofstream out(target, std::ios::binary);
+	if (out) {
+		out.write((char*)(&desc.size), sizeof(GLint));
+		out.write((char*)(&desc.width), sizeof(GLint));
+		out.write((char*)(&desc.height), sizeof(GLint));
+		out.write((char*)(&desc.format), sizeof(GLint));
+		out.write((char*)(desc.data), desc.size);
+	}
+}
+
+/***********************************************************************************/
+unsigned int ResourceManager::LoadTexture(const std::filesystem::path& path, const bool useMipMaps, const bool useUnalignedUnpack) {
+
+	if (path.filename().empty()) {
+		return 0;
+	}
 	
-	if (val != m_textureCache.end()) {
+	const auto compressedFilePath{ buildTextureCachePath(path.stem()) };
+	const auto compressedImageExists{ std::filesystem::exists(compressedFilePath) };
+
+	const std::filesystem::path pathToLoad = compressedImageExists ? compressedFilePath : path;
+
+	// Check if texture is already loaded in memory
+	if (const auto val = m_textureCache.find(pathToLoad); val != m_textureCache.end()) {
 		// Found it
 		return val->second;
 	}
-
+	
 	if (useUnalignedUnpack) {
 		glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 	}
 
-	// Create and cache a new texture
 	unsigned int textureID;
 	glGenTextures(1, &textureID);
 
-	int width, height, nrComponents;
-	unsigned char* data = stbi_load(path.data(), &width, &height, &nrComponents, 0);
-	if (!data) {
-		std::cerr << "Failed to load texture: " << path << std::endl;
+	if (compressedImageExists) {
+		std::ifstream in(compressedFilePath, std::ios::binary);
+		in.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+		if (!in) {
+			return 0;
+		}
+
+		GLint size{ -1 };
+		GLint width{ -1 };
+		GLint height{ -1 };
+		GLint format{ -1 };
+
+		in.read((char*)&size, sizeof(GLint));
+		if (in.fail() || size == -1) {
+			return 0;
+		}
+
+		in.read((char*)&width, sizeof(GLint));
+		in.read((char*)&height, sizeof(GLint));
+		in.read((char*)&format, sizeof(GLint));
+
+		auto compressedData = std::make_unique<unsigned char[]>(size);
+		in.read((char*)compressedData.get(), size);
+
+		glBindTexture(GL_TEXTURE_2D, textureID);
+		glCompressedTexImage2D(GL_TEXTURE_2D, 0, format, width, height, 0, size, compressedData.get());
+		
+	} else {
+		int width = 0, height = 0, nrComponents = 0;
+		unsigned char* data = stbi_load(pathToLoad.c_str(), &width, &height, &nrComponents, 0);
+		if (!data) {
+			std::cerr << "Failed to load texture: " << path << std::endl;
+			glDeleteTextures(1, &textureID);
+			stbi_image_free(data);
+			return 0;
+		}
+
+		GLenum format = 0;
+		GLenum internalFormat = 0;
+		switch (nrComponents) {
+		case 1:
+			format = GL_RED;
+			internalFormat = GL_COMPRESSED_RED;
+			break;
+		case 3:
+			format = GL_RGB;
+			internalFormat = GL_COMPRESSED_RGB;
+			break;
+		case 4:
+			format = GL_RGBA;
+			internalFormat = GL_COMPRESSED_RGBA;
+			break;
+		}
+
+		glBindTexture(GL_TEXTURE_2D, textureID);
+		
+		glHint(GL_TEXTURE_COMPRESSION_HINT, GL_DONT_CARE);
+		glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, width, height, 0, format, GL_UNSIGNED_BYTE, data);
+
 		stbi_image_free(data);
-		return 0;
-	}
 
-	GLenum format = 0;
-	GLenum internalFormat = 0;
-	switch (nrComponents) {
-	case 1:
-		format = GL_RED;
-		internalFormat = GL_COMPRESSED_RED;
-		break;
-	case 3:
-		format = GL_RGB;
-		internalFormat = GL_COMPRESSED_RGB;
-		break;
-	case 4:
-		format = GL_RGBA;
-		internalFormat = GL_COMPRESSED_RGBA;
-		break;
-	}
+		GLint compressed = GL_FALSE;
+		glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_COMPRESSED, &compressed);
+		if (compressed == GL_TRUE) {
+			GLint compressedSize = -1;
+			glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_COMPRESSED_IMAGE_SIZE, &compressedSize);
 
-	glBindTexture(GL_TEXTURE_2D, textureID);
-	glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, width, height, 0, format, GL_UNSIGNED_BYTE, data);
+			GLint internalFormat = -1;
+			glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_INTERNAL_FORMAT, &internalFormat);
+
+			auto compressedData = std::make_unique<unsigned char[]>(compressedSize);
+			glGetCompressedTexImage(GL_TEXTURE_2D, 0, (GLvoid*)compressedData.get());
+
+			const CompressedImageDesc desc {
+				.width = width,
+				.height = height,
+				.size = compressedSize,
+				.format = internalFormat,
+				.data = compressedData.get()
+			};
+
+			saveCompressedImageToDisk(compressedFilePath, desc);
+		}
+	}
+	
 	if (useMipMaps) {
 		glGenerateMipmap(GL_TEXTURE_2D);
 	}
-
-	stbi_image_free(data);
-
-#ifdef _DEBUG
-	std::cout << "Resource Manager: loaded texture: " << path << std::endl;
-#endif
 
 	if (useUnalignedUnpack) {
 		glPixelStorei(GL_UNPACK_ALIGNMENT, 0);
 	}
 
-	return m_textureCache.try_emplace(path.data(), textureID).first->second;
+	return m_textureCache.try_emplace(path, textureID).first->second;
 }
 
 /***********************************************************************************/

--- a/MP-APS/ResourceManager.h
+++ b/MP-APS/ResourceManager.h
@@ -26,7 +26,7 @@ public:
 	// Loads an HDR image and generates an OpenGL floating-point texture.
 	unsigned int LoadHDRI(const std::string_view path) const;
 	// Loads an image (if not cached) and generates an OpenGL texture.
-	unsigned int LoadTexture(const std::string_view path, const bool useMipMaps = true, const bool useUnalignedUnpack = false);
+	unsigned int LoadTexture(const std::filesystem::path& path, const bool useMipMaps = true, const bool useUnalignedUnpack = false);
 	// Loads a binary file into a vector and returns it
 	std::vector<char> LoadBinaryFile(const std::string_view path) const;
 	


### PR DESCRIPTION
Was playing around with [Valgrind](https://valgrind.org/docs/manual/ms-manual.html) to track down what I felt was excessive memory usage by the engine, which brought me to learn about on-the-fly texture compression offered by the OpenGL driver. Figured we should use that to reduce system memory usage, with the _downside being we will have longer startup time as now the driver has to compress the images on the fly before uploading to the GPU_. 

* Loads/saves compressed textures to disk in `Data/cache/textures/*.bin`.

Used the corresponding enums from Table 3 in https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexImage2D.xhtml

With the OOB PBR Sponza scene, here are the results:
|| RAM | VRAM |
|------|-------|-------|
| Without compression | 610 MB | 1657 MB |
| With compression | 397 MB | 1464 MB | 
| **Difference** | **-35%** | **-12%** |

## Screenshots

### Before
Compiled with `-g`
![Screenshot from 2021-12-30 20-30-10](https://user-images.githubusercontent.com/5572045/147795564-5957d5c3-0e7d-439f-b8a8-6e3ecb09a24a.png)

Compiled without `-g`
![image](https://user-images.githubusercontent.com/5572045/147795754-706dd454-0354-4661-b452-eb507ab4cd91.png)


### After
Compiled with `-g`
![Screenshot from 2021-12-30 20-32-05](https://user-images.githubusercontent.com/5572045/147795568-7e7e4e56-12e6-433d-82b2-a5e3e7c0056e.png)

Compiled without `-g`
![Screenshot from 2021-12-30 20-34-15](https://user-images.githubusercontent.com/5572045/147795570-360b93d9-19c9-43a9-8cbe-16f259d4f958.png)
